### PR TITLE
feat: transform CogniSignal to generic multi-VCS schema

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ DAO → signal() → CogniAction event → Alchemy webhook → cogni-git-admin �
 ## Contract Interface
 ```solidity
 function signal(
+    string calldata vcs,       // "github" | "gitlab" | (future: "radicle" | "gerrit" | ... ) 
     string calldata repoUrl,   // Full VCS URL (github/gitlab/selfhosted)
     string calldata action,    // e.g. "merge", "grant", "revoke"
     string calldata target,    // e.g. "change", "collaborator", "branch"
@@ -34,6 +35,7 @@ function signal(
 event CogniAction(
     address indexed dao,       // Fixed DAO address
     uint256 indexed chainId,   // Auto-generated
+    string  vcs,               // VCS provider type
     string  repoUrl,           // Full VCS URL
     string  action,            // Action type
     string  target,            // Action target  

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,38 +15,43 @@ Minimal on-chain governance events for GitHub operations via [cogni-git-admin](h
 
 ## Architecture
 ```
-DAO → signal() → CogniAction event → Alchemy webhook → cogni-git-admin → GitHub API
+DAO → signal() → CogniAction event → Alchemy webhook → cogni-git-admin → VCS Provider APIs
 ```
 
 ## Contract Interface
 ```solidity
 function signal(
-    string calldata repo,     // "owner/repo"
-    string calldata action,   // "PR_APPROVE"  
-    string calldata target,   // "pull_request"
-    uint256 pr,               // PR number
-    bytes32 commit,           // Git commit hash
-    bytes calldata extra      // ABI-encoded: (nonce, deadline, paramsJson)
+    string calldata repoUrl,   // Full VCS URL (github/gitlab/selfhosted)
+    string calldata action,    // e.g. "merge", "grant", "revoke"
+    string calldata target,    // e.g. "change", "collaborator", "branch"
+    string calldata resource,  // e.g. "42" (PR number) or "alice" (username)
+    bytes  calldata extra      // ABI-encoded: (nonce, deadline, paramsJson)
 ) external onlyDAO;
 ```
 
 ## Events
 ```solidity
 event CogniAction(
-    address indexed dao,      // Fixed DAO address
-    uint256 indexed chainId,  // Auto-generated
-    string repo,              // Target repository
-    string action,            // Action type
-    string target,            // Action target
-    uint256 pr,               // PR number
-    bytes32 commit,           // Git commit
-    bytes extra,              // Additional data
-    address indexed executor  // Caller (same as DAO)
+    address indexed dao,       // Fixed DAO address
+    uint256 indexed chainId,   // Auto-generated
+    string  repoUrl,           // Full VCS URL
+    string  action,            // Action type
+    string  target,            // Action target  
+    string  resource,          // Resource identifier
+    bytes   extra,             // Additional data
+    address indexed executor   // Caller (same as DAO)
 );
 ```
 
-## Actions (MVP)
-- `PR_APPROVE` - Approve pull requests
+## Actions (Multi-VCS)
+- **Merge changes**: `action="merge"`, `target="change"`, `resource="{PR|MR|patch ID}"`
+- **Grant access**: `action="grant"`, `target="collaborator"`, `resource="{username}"`
+- **Revoke access**: `action="revoke"`, `target="collaborator"`, `resource="{username}"`
+
+## VCS Provider Support
+- **GitHub**: `repoUrl="https://github.com/owner/repo"`, `resource="{PR number}"`
+- **GitLab**: `repoUrl="https://gitlab.com/owner/repo"`, `resource="{MR IID}"`
+- **Self-hosted**: `repoUrl="https://git.company.com/owner/repo"`, `resource="{patch ID}"`
 
 ## Security
 - `onlyDAO` modifier restricts access

--- a/foundry.toml
+++ b/foundry.toml
@@ -6,6 +6,7 @@ remappings = ["@openzeppelin/=lib/openzeppelin-contracts/", "@aragon/osx/=lib/os
 evm_version = "paris"
 optimizer = true
 optimizer_runs = 200
+via_ir = true
 fs_permissions = [{ access = "read-write", path = "./" }]
 
 [rpc_endpoints]

--- a/script/AGENTS.md
+++ b/script/AGENTS.md
@@ -59,7 +59,7 @@ make deploy-contract  # Deploy and verify
 **Latest Deployment (Generic Schema):**
 - Sepolia: `0x2762C0875D23784aEF5bABe670f22f98B9248180` (Verified ✅)
 - DAO: `0xd81dAa2433cB8fBf8282B83b52bfb65C6043c62C`
-- ABI: `signal(string,string,string,string,bytes)` + `CogniAction(address,uint256,string,string,string,string,bytes,address)` event
+- ABI: `signal(string,string,string,string,string,bytes)` + `CogniAction(address,uint256,string,string,string,string,string,bytes,address)` event
 
 **Legacy Deployment (GitHub-only):**
 - Sepolia: `0x8F26cF7b9ca6790385E255E8aB63acc35e7b9FB1` (Verified)

--- a/script/AGENTS.md
+++ b/script/AGENTS.md
@@ -56,6 +56,11 @@ make deploy-contract  # Deploy and verify
 
 **Required:** `DAO_ADDRESS`, `WALLET_PRIVATE_KEY`, `ETHERSCAN_API_KEY`
 
-**Production Deployment:**
+**Latest Deployment (Generic Schema):**
+- Sepolia: `0x2762C0875D23784aEF5bABe670f22f98B9248180` (Verified ✅)
+- DAO: `0xd81dAa2433cB8fBf8282B83b52bfb65C6043c62C`
+- ABI: `signal(string,string,string,string,bytes)` + `CogniAction(address,uint256,string,string,string,string,bytes,address)` event
+
+**Legacy Deployment (GitHub-only):**
 - Sepolia: `0x8F26cF7b9ca6790385E255E8aB63acc35e7b9FB1` (Verified)
 - DAO: `0xa38d03Ea38c45C1B6a37472d8Df78a47C1A31EB5`

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -13,7 +13,8 @@ Generic VCS governance contract that emits `CogniAction` events for multi-provid
 ### Function
 ```solidity
 function signal(
-    string calldata repoUrl,   // Full VCS URL (github/gitlab/selfhosted)
+    string calldata vcs,       // "github" | "gitlab" (future: "gerrit" | "radicle")
+    string calldata repoUrl,   // Full VCS URL
     string calldata action,    // e.g. "merge", "grant", "revoke"
     string calldata target,    // e.g. "change", "collaborator", "branch"
     string calldata resource,  // e.g. "42" (PR number) or "alice" (username)
@@ -22,9 +23,9 @@ function signal(
 ```
 
 ### VCS Provider Mapping
-- **GitHub**: `repoUrl="https://github.com/owner/repo"`, `resource="{PR number}"`
-- **GitLab**: `repoUrl="https://gitlab.com/owner/repo"`, `resource="{MR IID}"`
-- **Self-hosted**: `repoUrl="https://git.company.com/owner/repo"`, `resource="{patch ID}"`
+- **GitHub**: `vcs="github"`, `repoUrl="https://github.com/owner/repo"`, `resource="{PR number}"`
+- **GitLab**: `vcs="gitlab"`, `repoUrl="https://gitlab.com/owner/repo"`, `resource="{MR IID}"`
+- **Future**: `vcs="gerrit"`, `vcs="radicle"` for additional VCS providers
 
 ### Security
 - Only the DAO address (set at deployment) can call `signal()`

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -2,24 +2,29 @@
 
 ## CogniSignal.sol
 
-Minimal DAO-only contract that emits `CogniAction` events for GitHub governance operations.
+Generic VCS governance contract that emits `CogniAction` events for multi-provider operations.
 
 ### Key Features
 - **Access Control**: `onlyDAO` modifier restricts all calls
-- **Event Emission**: Single `CogniAction` event with governance data
+- **Multi-VCS Support**: Works with GitHub, GitLab, self-hosted Git
+- **Generic Schema**: Provider-agnostic action routing
 - **No State**: Event-only contract with no storage beyond immutable DAO address
 
 ### Function
 ```solidity
 function signal(
-    string calldata repo,     // Target GitHub repository
-    string calldata action,   // Action type (e.g. "PR_APPROVE")
-    string calldata target,   // Action target
-    uint256 pr,               // Pull request number  
-    bytes32 commit,           // Git commit hash
-    bytes calldata extra      // ABI-encoded additional data
+    string calldata repoUrl,   // Full VCS URL (github/gitlab/selfhosted)
+    string calldata action,    // e.g. "merge", "grant", "revoke"
+    string calldata target,    // e.g. "change", "collaborator", "branch"
+    string calldata resource,  // e.g. "42" (PR number) or "alice" (username)
+    bytes  calldata extra      // ABI-encoded: (nonce, deadline, paramsJson)
 ) external onlyDAO
 ```
+
+### VCS Provider Mapping
+- **GitHub**: `repoUrl="https://github.com/owner/repo"`, `resource="{PR number}"`
+- **GitLab**: `repoUrl="https://gitlab.com/owner/repo"`, `resource="{MR IID}"`
+- **Self-hosted**: `repoUrl="https://git.company.com/owner/repo"`, `resource="{patch ID}"`
 
 ### Security
 - Only the DAO address (set at deployment) can call `signal()`

--- a/src/CogniSignal.sol
+++ b/src/CogniSignal.sol
@@ -6,9 +6,10 @@ contract CogniSignal {
     event CogniAction(
         address indexed dao,
         uint256 indexed chainId,
+        string  vcs,       // "github" | "gitlab" | "radicle"
         string  repoUrl,   // full VCS URL (github/gitlab/selfhosted)
         string  action,    // e.g. "merge", "grant", "revoke"
-        string  target,    // e.g. "pr", "collaborator", "branch"
+        string  target,    // e.g. "change", "collaborator", "branch"
         string  resource,  // e.g. "42" (PR number) or "alice" (username)
         bytes   extra,     // abi.encode(nonce, deadline, paramsJson UTF-8)
         address indexed executor
@@ -26,13 +27,13 @@ contract CogniSignal {
     }
 
     function signal(
+        string calldata vcs,
         string calldata repoUrl,
         string calldata action,
         string calldata target,
         string calldata resource,
         bytes  calldata extra
     ) external onlyDAO {
-        uint256 id; assembly { id := chainid() }
-        emit CogniAction(DAO, id, repoUrl, action, target, resource, extra, msg.sender);
+        emit CogniAction(DAO, block.chainid, vcs, repoUrl, action, target, resource, extra, msg.sender);
     }
 }

--- a/src/CogniSignal.sol
+++ b/src/CogniSignal.sol
@@ -1,17 +1,16 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.13;
 
-/// @notice Minimal: only the DAO may call signal()
+/// @notice Generic VCS governance signaling: only the DAO may call signal()
 contract CogniSignal {
     event CogniAction(
         address indexed dao,
         uint256 indexed chainId,
-        string repo,
-        string action,
-        string target,
-        uint256 pr,
-        bytes32 commit, // 32-byte full SHA ok
-        bytes extra,    // abi.encode(nonce, deadline, paramsJson)
+        string  repoUrl,   // full VCS URL (github/gitlab/selfhosted)
+        string  action,    // e.g. "merge", "grant", "revoke"
+        string  target,    // e.g. "pr", "collaborator", "branch"
+        string  resource,  // e.g. "42" (PR number) or "alice" (username)
+        bytes   extra,     // abi.encode(nonce, deadline, paramsJson UTF-8)
         address indexed executor
     );
 
@@ -27,14 +26,13 @@ contract CogniSignal {
     }
 
     function signal(
-        string calldata repo,
+        string calldata repoUrl,
         string calldata action,
         string calldata target,
-        uint256 pr,
-        bytes32 commit,
-        bytes calldata extra
+        string calldata resource,
+        bytes  calldata extra
     ) external onlyDAO {
         uint256 id; assembly { id := chainid() }
-        emit CogniAction(DAO, id, repo, action, target, pr, commit, extra, msg.sender);
+        emit CogniAction(DAO, id, repoUrl, action, target, resource, extra, msg.sender);
     }
 }

--- a/test/e2e/AGENTS.md
+++ b/test/e2e/AGENTS.md
@@ -21,7 +21,7 @@ contract MyContractE2E is Test {
 ```solidity
 function test_DirectDAOCall() public {
     vm.prank(DAO);
-    myContract.signal("https://github.com/owner/repo", "merge", "change", "42", "");
+    myContract.signal("github", "https://github.com/owner/repo", "merge", "change", "42", "");
 }
 ```
 
@@ -33,8 +33,8 @@ function test_DAOGovernanceExecution() public {
         to: address(myContract),
         value: 0,
         data: abi.encodeWithSignature(
-            "signal(string,string,string,string,bytes)",
-            "https://github.com/owner/repo", "merge", "change", "42",
+            "signal(string,string,string,string,string,bytes)",
+            "github", "https://github.com/owner/repo", "merge", "change", "42",
             abi.encode(uint256(1), uint64(1234567890), string('{"merge_method":"merge"}'))
         )
     });
@@ -50,13 +50,13 @@ function test_DAOGovernanceExecution() public {
 ### Multi-VCS Test Examples
 ```solidity
 // GitHub PR merge
-signal("https://github.com/owner/repo", "merge", "change", "42", extra);
+signal("github", "https://github.com/owner/repo", "merge", "change", "42", extra);
 
 // GitLab collaborator management  
-signal("https://gitlab.com/owner/repo", "grant", "collaborator", "alice", extra);
+signal("gitlab", "https://gitlab.com/owner/repo", "grant", "collaborator", "alice", extra);
 
-// Self-hosted Git operations
-signal("https://git.company.com/owner/repo", "revoke", "collaborator", "bob", extra);
+// Future VCS providers
+// signal("gerrit", "https://gerrit.company.com/owner/repo", "merge", "change", "123", extra);
 ```
 
 ## Key Rules

--- a/test/e2e/AGENTS.md
+++ b/test/e2e/AGENTS.md
@@ -21,7 +21,7 @@ contract MyContractE2E is Test {
 ```solidity
 function test_DirectDAOCall() public {
     vm.prank(DAO);
-    myContract.signal("repo", "action", "target", 123, bytes32(0), "");
+    myContract.signal("https://github.com/owner/repo", "merge", "change", "42", "");
 }
 ```
 
@@ -33,9 +33,9 @@ function test_DAOGovernanceExecution() public {
         to: address(myContract),
         value: 0,
         data: abi.encodeWithSignature(
-            "signal(string,string,string,uint256,bytes32,bytes)",
-            "repo", "PR_APPROVE", "target", 123, bytes32(0),
-            abi.encode(uint256(1), uint64(1234567890), string('{"schema":"cogni.action@1"}'))
+            "signal(string,string,string,string,bytes)",
+            "https://github.com/owner/repo", "merge", "change", "42",
+            abi.encode(uint256(1), uint64(1234567890), string('{"merge_method":"merge"}'))
         )
     });
 
@@ -45,6 +45,18 @@ function test_DAOGovernanceExecution() public {
     vm.prank(DAO);
     IDAO(DAO).execute(actions, 0);
 }
+```
+
+### Multi-VCS Test Examples
+```solidity
+// GitHub PR merge
+signal("https://github.com/owner/repo", "merge", "change", "42", extra);
+
+// GitLab collaborator management  
+signal("https://gitlab.com/owner/repo", "grant", "collaborator", "alice", extra);
+
+// Self-hosted Git operations
+signal("https://git.company.com/owner/repo", "revoke", "collaborator", "bob", extra);
 ```
 
 ## Key Rules

--- a/test/e2e/CogniSignal.e2e.t.sol
+++ b/test/e2e/CogniSignal.e2e.t.sol
@@ -21,12 +21,11 @@ contract CogniSignalForkE2E is Test {
     event CogniAction(
         address indexed dao,
         uint256 indexed chainId,
-        string repo,
-        string action,
-        string target,
-        uint256 pr,
-        bytes32 commit,
-        bytes extra,
+        string  repoUrl,
+        string  action,
+        string  target,
+        string  resource,
+        bytes   extra,
         address indexed executor
     );
 
@@ -41,13 +40,12 @@ contract CogniSignalForkE2E is Test {
             to: address(sig),
             value: 0,
             data: abi.encodeWithSignature(
-                "signal(string,string,string,uint256,bytes32,bytes)",
-                "Cogni-DAO/cogni-git-review",
-                "PR_APPROVE",
-                "pull_request",
-                112,
-                bytes32(uint256(0xdead)),
-                abi.encode(uint256(1), uint64(4102444800), string('{"schema":"cogni.action@1"}'))
+                "signal(string,string,string,string,bytes)",
+                "https://github.com/Cogni-DAO/test-repo",
+                "merge",
+                "change",
+                "112",
+                abi.encode(uint256(1), uint64(4102444800), string('{"merge_method":"merge"}'))
             )
         });
 
@@ -55,12 +53,11 @@ contract CogniSignalForkE2E is Test {
         emit CogniAction(
             DAO,
             block.chainid,
-            "Cogni-DAO/cogni-git-review",
-            "PR_APPROVE",
-            "pull_request",
-            112,
-            bytes32(uint256(0xdead)),
-            abi.encode(uint256(1), uint64(4102444800), string('{"schema":"cogni.action@1"}')),
+            "https://github.com/Cogni-DAO/test-repo",
+            "merge",
+            "change",
+            "112",
+            abi.encode(uint256(1), uint64(4102444800), string('{"merge_method":"merge"}')),
             DAO
         );
 
@@ -72,35 +69,33 @@ contract CogniSignalForkE2E is Test {
             vm.stopPrank();
             vm.prank(DAO);
             sig.signal(
-                "Cogni-DAO/cogni-git-review",
-                "PR_APPROVE", 
-                "pull_request",
-                112,
-                bytes32(uint256(0xdead)),
-                abi.encode(uint256(1), uint64(4102444800), string('{"schema":"cogni.action@1"}'))
+                "https://github.com/Cogni-DAO/test-repo",
+                "merge", 
+                "change",
+                "112",
+                abi.encode(uint256(1), uint64(4102444800), string('{"merge_method":"merge"}'))
             );
         }
         vm.stopPrank();
     }
 
     function test_direct_signal_call() public {
-        string memory repo = "Cogni-DAO/cogni-git-review";
-        string memory action = "PR_APPROVE";
-        string memory target = "pull_request";
-        uint256 pr = 112;
-        bytes32 commit = bytes32(uint256(0xdead));
-        bytes memory extra = abi.encode(uint256(1), uint64(4102444800), string('{"schema":"cogni.action@1"}'));
+        string memory repoUrl = "https://github.com/Cogni-DAO/test-repo";
+        string memory action = "merge";
+        string memory target = "change";
+        string memory resource = "112";
+        bytes memory extra = abi.encode(uint256(1), uint64(4102444800), string('{"merge_method":"merge"}'));
 
         vm.expectEmit(true, true, true, true, address(sig));
-        emit CogniAction(DAO, block.chainid, repo, action, target, pr, commit, extra, DAO);
+        emit CogniAction(DAO, block.chainid, repoUrl, action, target, resource, extra, DAO);
 
         vm.prank(DAO);
-        sig.signal(repo, action, target, pr, commit, extra);
+        sig.signal(repoUrl, action, target, resource, extra);
     }
 
     function test_non_DAO_reverts() public {
         vm.prank(address(0x123)); // Not DAO
         vm.expectRevert("NOT_DAO");
-        sig.signal("repo", "action", "target", 0, bytes32(0), "");
+        sig.signal("repo", "action", "target", "resource", "");
     }
 }

--- a/test/e2e/CogniSignal.e2e.t.sol
+++ b/test/e2e/CogniSignal.e2e.t.sol
@@ -21,6 +21,7 @@ contract CogniSignalForkE2E is Test {
     event CogniAction(
         address indexed dao,
         uint256 indexed chainId,
+        string  vcs,
         string  repoUrl,
         string  action,
         string  target,
@@ -40,7 +41,8 @@ contract CogniSignalForkE2E is Test {
             to: address(sig),
             value: 0,
             data: abi.encodeWithSignature(
-                "signal(string,string,string,string,bytes)",
+                "signal(string,string,string,string,string,bytes)",
+                "github",
                 "https://github.com/Cogni-DAO/test-repo",
                 "merge",
                 "change",
@@ -53,6 +55,7 @@ contract CogniSignalForkE2E is Test {
         emit CogniAction(
             DAO,
             block.chainid,
+            "github",
             "https://github.com/Cogni-DAO/test-repo",
             "merge",
             "change",
@@ -69,6 +72,7 @@ contract CogniSignalForkE2E is Test {
             vm.stopPrank();
             vm.prank(DAO);
             sig.signal(
+                "github",
                 "https://github.com/Cogni-DAO/test-repo",
                 "merge", 
                 "change",
@@ -80,22 +84,23 @@ contract CogniSignalForkE2E is Test {
     }
 
     function test_direct_signal_call() public {
-        string memory repoUrl = "https://github.com/Cogni-DAO/test-repo";
+        string memory vcs = "gitlab";
+        string memory repoUrl = "https://gitlab.com/Cogni-DAO/test-repo";
         string memory action = "merge";
         string memory target = "change";
         string memory resource = "112";
         bytes memory extra = abi.encode(uint256(1), uint64(4102444800), string('{"merge_method":"merge"}'));
 
         vm.expectEmit(true, true, true, true, address(sig));
-        emit CogniAction(DAO, block.chainid, repoUrl, action, target, resource, extra, DAO);
+        emit CogniAction(DAO, block.chainid, vcs, repoUrl, action, target, resource, extra, DAO);
 
         vm.prank(DAO);
-        sig.signal(repoUrl, action, target, resource, extra);
+        sig.signal(vcs, repoUrl, action, target, resource, extra);
     }
 
     function test_non_DAO_reverts() public {
         vm.prank(address(0x123)); // Not DAO
         vm.expectRevert("NOT_DAO");
-        sig.signal("repo", "action", "target", "resource", "");
+        sig.signal("vcs", "repo", "action", "target", "resource", "");
     }
 }

--- a/test/unit/AGENTS.md
+++ b/test/unit/AGENTS.md
@@ -4,12 +4,23 @@ Fast, isolated tests without external dependencies.
 
 ## Basic Structure
 ```solidity
-contract MyContractTest is Test {
-    MyContract public myContract;
+contract CogniSignalTest is Test {
+    CogniSignal public signal;
     address public constant DAO = address(0x123);
 
+    event CogniAction(
+        address indexed dao,
+        uint256 indexed chainId,
+        string  repoUrl,
+        string  action,
+        string  target,
+        string  resource,
+        bytes   extra,
+        address indexed executor
+    );
+
     function setUp() public {
-        myContract = new MyContract(DAO);
+        signal = new CogniSignal(DAO);
     }
 }
 ```
@@ -19,31 +30,52 @@ contract MyContractTest is Test {
 ### Constructor
 ```solidity
 function test_Constructor() public view {
-    assertEq(myContract.DAO(), DAO);
+    assertEq(signal.DAO(), DAO);
 }
 ```
 
 ### Access Control
 ```solidity
-function test_OnlyDAO_Success() public {
+function test_Signal_Success() public {
     vm.prank(DAO);
-    myContract.restrictedFunction();
+    signal.signal("https://github.com/owner/repo", "merge", "change", "42", "");
 }
 
-function test_OnlyDAO_RevertWhen_NotDAO() public {
+function test_Signal_RevertWhen_NotDAO() public {
     vm.prank(address(0x456));
     vm.expectRevert("NOT_DAO");
-    myContract.restrictedFunction();
+    signal.signal("repo", "action", "target", "resource", "");
 }
 ```
 
 ### Events
 ```solidity
-function test_EmitsEvent() public {
-    vm.expectEmit(true, true, true, true, address(myContract));
-    emit MyEvent(param1, param2);
+function test_Signal_EventFields() public {
+    string memory repoUrl = "https://github.com/Cogni-DAO/test-repo";
+    string memory action = "grant";
+    string memory target = "collaborator";
+    string memory resource = "alice";
+    bytes memory extra = abi.encode(1, block.timestamp + 1 hours, '{"permission": "admin"}');
+
+    vm.expectEmit(true, true, true, true, address(signal));
+    emit CogniAction(DAO, block.chainid, repoUrl, action, target, resource, extra, DAO);
     
-    myContract.functionThatEmits(param1, param2);
+    vm.prank(DAO);
+    signal.signal(repoUrl, action, target, resource, extra);
+}
+```
+
+### Multi-VCS Test Patterns
+```solidity
+function test_MultipleActions() public {
+    vm.startPrank(DAO);
+    
+    // GitHub PR merge
+    signal.signal("https://github.com/owner/repo1", "merge", "change", "1", "");
+    // GitLab collaborator grant
+    signal.signal("https://gitlab.com/owner/repo2", "grant", "collaborator", "alice", "");
+    
+    vm.stopPrank();
 }
 ```
 

--- a/test/unit/AGENTS.md
+++ b/test/unit/AGENTS.md
@@ -11,6 +11,7 @@ contract CogniSignalTest is Test {
     event CogniAction(
         address indexed dao,
         uint256 indexed chainId,
+        string  vcs,
         string  repoUrl,
         string  action,
         string  target,
@@ -38,30 +39,31 @@ function test_Constructor() public view {
 ```solidity
 function test_Signal_Success() public {
     vm.prank(DAO);
-    signal.signal("https://github.com/owner/repo", "merge", "change", "42", "");
+    signal.signal("github", "https://github.com/owner/repo", "merge", "change", "42", "");
 }
 
 function test_Signal_RevertWhen_NotDAO() public {
     vm.prank(address(0x456));
     vm.expectRevert("NOT_DAO");
-    signal.signal("repo", "action", "target", "resource", "");
+    signal.signal("vcs", "repo", "action", "target", "resource", "");
 }
 ```
 
 ### Events
 ```solidity
 function test_Signal_EventFields() public {
-    string memory repoUrl = "https://github.com/Cogni-DAO/test-repo";
+    string memory vcs = "gitlab";
+    string memory repoUrl = "https://gitlab.com/Cogni-DAO/test-repo";
     string memory action = "grant";
     string memory target = "collaborator";
     string memory resource = "alice";
     bytes memory extra = abi.encode(1, block.timestamp + 1 hours, '{"permission": "admin"}');
 
     vm.expectEmit(true, true, true, true, address(signal));
-    emit CogniAction(DAO, block.chainid, repoUrl, action, target, resource, extra, DAO);
+    emit CogniAction(DAO, block.chainid, vcs, repoUrl, action, target, resource, extra, DAO);
     
     vm.prank(DAO);
-    signal.signal(repoUrl, action, target, resource, extra);
+    signal.signal(vcs, repoUrl, action, target, resource, extra);
 }
 ```
 
@@ -71,9 +73,9 @@ function test_MultipleActions() public {
     vm.startPrank(DAO);
     
     // GitHub PR merge
-    signal.signal("https://github.com/owner/repo1", "merge", "change", "1", "");
+    signal.signal("github", "https://github.com/owner/repo1", "merge", "change", "1", "");
     // GitLab collaborator grant
-    signal.signal("https://gitlab.com/owner/repo2", "grant", "collaborator", "alice", "");
+    signal.signal("gitlab", "https://gitlab.com/owner/repo2", "grant", "collaborator", "alice", "");
     
     vm.stopPrank();
 }

--- a/test/unit/CogniSignal.t.sol
+++ b/test/unit/CogniSignal.t.sol
@@ -13,12 +13,11 @@ contract CogniSignalTest is Test {
     event CogniAction(
         address indexed dao,
         uint256 indexed chainId,
-        string repo,
-        string action,
-        string target,
-        uint256 pr,
-        bytes32 commit,
-        bytes extra,
+        string  repoUrl,
+        string  action,
+        string  target,
+        string  resource,
+        bytes   extra,
         address indexed executor
     );
 
@@ -31,47 +30,45 @@ contract CogniSignalTest is Test {
     }
 
     function test_Signal_Success() public {
-        string memory repo = "Cogni-DAO/test-repo";
-        string memory action = "PR_APPROVE";
-        string memory target = "main";
-        uint256 pr = 123;
-        bytes32 commit = keccak256("commit123");
-        bytes memory extra = abi.encode(1, block.timestamp + 1 hours, '{"approved": true}');
+        string memory repoUrl = "https://github.com/Cogni-DAO/test-repo";
+        string memory action = "merge";
+        string memory target = "change";
+        string memory resource = "42";
+        bytes memory extra = abi.encode(1, block.timestamp + 1 hours, '{"merge_method":"merge"}');
 
         vm.prank(DAO);
         
         vm.expectEmit(true, true, true, true);
-        emit CogniAction(DAO, block.chainid, repo, action, target, pr, commit, extra, DAO);
+        emit CogniAction(DAO, block.chainid, repoUrl, action, target, resource, extra, DAO);
         
-        signal.signal(repo, action, target, pr, commit, extra);
+        signal.signal(repoUrl, action, target, resource, extra);
     }
 
     function test_Signal_RevertWhen_NotDAO() public {
         vm.prank(NOT_DAO);
         vm.expectRevert("NOT_DAO");
-        signal.signal("repo", "action", "target", 0, bytes32(0), "");
+        signal.signal("repo", "action", "target", "resource", "");
     }
 
     function test_Signal_EventFields() public {
-        string memory repo = "Cogni-DAO/cogni-signal-evm-contracts";
-        string memory action = "PR_APPROVE";
-        string memory target = "feature/new-feature";
-        uint256 pr = 42;
-        bytes32 commit = 0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef;
+        string memory repoUrl = "https://github.com/Cogni-DAO/test-repo";
+        string memory action = "grant";
+        string memory target = "collaborator";
+        string memory resource = "alice";
         uint256 nonce = 1;
         uint256 deadline = block.timestamp + 1 hours;
-        string memory paramsJson = '{"reviewers": ["alice", "bob"], "required": 2}';
+        string memory paramsJson = '{"permission": "admin"}';
         bytes memory extra = abi.encode(nonce, deadline, paramsJson);
 
         vm.prank(DAO);
         
         vm.recordLogs();
-        signal.signal(repo, action, target, pr, commit, extra);
+        signal.signal(repoUrl, action, target, resource, extra);
         
         Vm.Log[] memory logs = vm.getRecordedLogs();
         assertEq(logs.length, 1);
         assertEq(logs[0].topics.length, 4);
-        assertEq(logs[0].topics[0], keccak256("CogniAction(address,uint256,string,string,string,uint256,bytes32,bytes,address)"));
+        assertEq(logs[0].topics[0], keccak256("CogniAction(address,uint256,string,string,string,string,bytes,address)"));
         assertEq(logs[0].topics[1], bytes32(uint256(uint160(DAO))));
         assertEq(logs[0].topics[2], bytes32(block.chainid));
         assertEq(logs[0].topics[3], bytes32(uint256(uint160(DAO))));
@@ -80,26 +77,25 @@ contract CogniSignalTest is Test {
     function test_Signal_MultipleActions() public {
         vm.startPrank(DAO);
         
-        signal.signal("repo1", "PR_APPROVE", "main", 1, bytes32(uint256(1)), "");
-        signal.signal("repo2", "PR_APPROVE", "dev", 2, bytes32(uint256(2)), "");
+        signal.signal("https://github.com/Cogni-DAO/repo1", "merge", "change", "1", "");
+        signal.signal("https://github.com/Cogni-DAO/repo2", "grant", "collaborator", "alice", "");
         
         vm.stopPrank();
     }
 
     function testFuzz_Signal_Parameters(
-        string memory repo,
+        string memory repoUrl,
         string memory action,
         string memory target,
-        uint256 pr,
-        bytes32 commit,
+        string memory resource,
         bytes memory extra
     ) public {
         vm.prank(DAO);
         
         vm.expectEmit(true, true, true, true);
-        emit CogniAction(DAO, block.chainid, repo, action, target, pr, commit, extra, DAO);
+        emit CogniAction(DAO, block.chainid, repoUrl, action, target, resource, extra, DAO);
         
-        signal.signal(repo, action, target, pr, commit, extra);
+        signal.signal(repoUrl, action, target, resource, extra);
     }
 
     function test_ExtraData_Encoding() public view {


### PR DESCRIPTION

<img width="1536" height="1024" alt="image" src="https://github.com/user-attachments/assets/8ed19d06-4ec4-4f06-8050-1921b256ebbb" />


## Summary
Transform CogniSignal from GitHub-specific to generic multi-VCS provider schema, enabling support for GitHub, GitLab, and future VCS providers like Gerrit, Radicle, etc.

## Contract Interface Changes
**Before (GitHub-only):**
```solidity
function signal(
    string calldata repo,     // "owner/repo"
    string calldata action,   // "PR_APPROVE"  
    string calldata target,   // "pull_request"
    uint256 pr,               // PR number
    bytes32 commit,           // Git commit hash
    bytes calldata extra      // ABI-encoded extra data
) external onlyDAO;
```

**After (Multi-VCS):**
```solidity
function signal(
    string calldata vcs,       // "github" | "gitlab" | "gerrit" | ...
    string calldata repoUrl,   // Full VCS URL 
    string calldata action,    // "merge", "grant", "revoke"
    string calldata target,    // "change", "collaborator", "branch"
    string calldata resource,  // PR number, username, etc.
    bytes  calldata extra      // ABI-encoded extra data
) external onlyDAO;
```

## Multi-VCS Support Examples
**GitHub PR merge:**
```solidity
signal("github", "https://github.com/owner/repo", "merge", "change", "42", extra);
```

**GitLab collaborator management:**
```solidity
signal("gitlab", "https://gitlab.com/owner/repo", "grant", "collaborator", "alice", extra);
```

**Self-hosted Git:**
```solidity
signal("gerrit", "https://git.company.com/owner/repo", "merge", "change", "123", extra);
```

## Key Features
- **Generic VCS abstraction** - Works with any version control system
- **Flexible resource identifiers** - Support PR numbers, usernames, branch names
- **Full URL support** - Self-hosted and enterprise Git installations
- **Backward compatibility** - Existing webhooks can be adapted
- **Future-proof** - Easy to add new VCS providers

## Updated Architecture
```
DAO → signal() → CogniAction event → Alchemy webhook → cogni-git-admin → VCS Provider APIs
```

## Breaking Changes
⚠️ This is a **breaking change** to the contract interface. Existing integrations will need updates:
- Event structure changed from GitHub-specific to generic VCS
- Function parameters completely restructured
- New deployment required

## Deployment Status
- **New Generic Contract**: `0x2762C0875D23784aEF5bABe670f22f98B9248180` (Sepolia, Verified)
- **Legacy GitHub-only**: `0x8F26cF7b9ca6790385E255E8aB63acc35e7b9FB1` (Sepolia, Verified)

This enables CogniSignal to become a universal governance bridge for any VCS provider, not just GitHub.