### PR TITLE
feat: add automatic Etherscan contract verification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,9 +4,9 @@
 Minimal on-chain governance events for GitHub operations via [cogni-git-admin](https://github.com/Cogni-DAO/cogni-git-admin).
 
 ## Status: Proof of Concept Working ✅
-- **Contract:** `CogniSignal.sol` deployed and verified on Sepolia at `0x8F26cF7b9ca6790385E255E8aB63acc35e7b9FB1`
+- **Contract:** `CogniSignal.sol` deployed and verified on Sepolia at `0x7115D79246D1aE2D4bF5a6D5fA626B426fE8F5cD`
 - **Integration:** End-to-end with cogni-git-admin functioning
-- **Deployment:** `make dao-setup` deploys complete stack
+- **Deployment:** `make dao-setup` deploys complete stack with automatic verification
 
 ## Current Limitations (POC)
 - Single wallet execution for testing (not multi-signature governance)
@@ -65,9 +65,9 @@ event CogniAction(
 ```bash
 # Setup environment
 cp .env.TOKEN.example .env
-# Edit .env with WALLET_PRIVATE_KEY and EVM_RPC_URL
+# Edit .env with WALLET_PRIVATE_KEY, EVM_RPC_URL, and ETHERSCAN_API_KEY
 
-# Deploy complete stack
+# Deploy complete stack with automatic verification
 make dao-setup
 
 # Copy generated environment variables to cogni-git-admin

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,9 @@ dao-setup:
 	@echo "Checking required environment variables..."
 	@test -n "$(WALLET_PRIVATE_KEY)" || (echo "❌ WALLET_PRIVATE_KEY not set in .env" && exit 1)
 	@test -n "$(EVM_RPC_URL)" || (echo "❌ EVM_RPC_URL not set in .env" && exit 1)
+	@test -n "$(ETHERSCAN_API_KEY)" || (echo "❌ ETHERSCAN_API_KEY not set in .env" && exit 1)
 	@echo "✅ Environment variables loaded from .env"
-	forge script script/SetupDevChain.s.sol:SetupDevChain --rpc-url $(EVM_RPC_URL) --broadcast
+	forge script script/SetupDevChain.s.sol:SetupDevChain --rpc-url $(EVM_RPC_URL) --broadcast --verify
 
 deploy-contract:
 	@echo "Deploying CogniSignal contract with existing DAO"
@@ -20,5 +21,6 @@ deploy-contract:
 	@test -n "$(WALLET_PRIVATE_KEY)" || (echo "❌ WALLET_PRIVATE_KEY not set in .env" && exit 1)
 	@test -n "$(EVM_RPC_URL)" || (echo "❌ EVM_RPC_URL not set in .env" && exit 1)
 	@test -n "$(DAO_ADDRESS)" || (echo "❌ DAO_ADDRESS not set in .env" && exit 1)
+	@test -n "$(ETHERSCAN_API_KEY)" || (echo "❌ ETHERSCAN_API_KEY not set in .env" && exit 1)
 	@echo "✅ Environment variables loaded from .env"
-	forge script script/Deploy.s.sol:Deploy --rpc-url $(EVM_RPC_URL) --broadcast
+	forge script script/Deploy.s.sol:Deploy --rpc-url $(EVM_RPC_URL) --broadcast --verify

--- a/README.md
+++ b/README.md
@@ -49,6 +49,17 @@ Choose one provider and sign up for a free API key:
 2. Create endpoint → "Ethereum" → "Sepolia"
 3. Copy HTTP Provider URL
 
+### 4. Get Etherscan API Key (Required for Verification)
+Contract verification ensures transparency and enables interaction through Etherscan:
+
+1. Go to [etherscan.io/register](https://etherscan.io/register)
+2. Create free account and verify email
+3. Visit [etherscan.io/apidashboard](https://etherscan.io/apidashboard)
+4. Click "Add" to create new API key
+5. Copy the generated key: `YourApiKeyToken`
+
+💡 **Free tier** provides 100,000 requests/day - sufficient for development use.
+
 ## Quick Start
 
 ```bash
@@ -56,9 +67,9 @@ Choose one provider and sign up for a free API key:
 cp .env.TOKEN.example .env
 
 # 2. Edit .env with your values:
-# WALLET_PRIVATE_KEY=0x...    # From MetaMask account details
+# WALLET_PRIVATE_KEY=0x...    # From MetaMask account details  
 # EVM_RPC_URL=https://eth-sepolia...  # From step 3 above
-# ETHERSCAN_API_KEY=...       # For automatic contract verification
+# ETHERSCAN_API_KEY=YourApiKeyToken   # From step 4 above
 
 # 3. Deploy complete development stack with automatic verification
 make dao-setup
@@ -70,6 +81,22 @@ make dao-setup
 # Run tests
 forge test        
 forge build       
+```
+
+### Troubleshooting Verification
+
+**Common Issues:**
+- **"Could not detect deployment"**: Wait 30 seconds for Etherscan indexing, then retry
+- **"Pending in queue"**: Etherscan is processing - verification continues automatically
+- **API rate limits**: Free tier provides 100k requests/day - sufficient for development
+
+**Manual verification fallback:**
+```bash
+# If automatic verification fails, verify manually:
+forge verify-contract CONTRACT_ADDRESS src/CogniSignal.sol:CogniSignal \
+  --etherscan-api-key $ETHERSCAN_API_KEY \
+  --chain sepolia \
+  --constructor-args $(cast abi-encode "constructor(address)" $DAO_ADDRESS)
 ```
 
 ### Integration Output

--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ cp .env.TOKEN.example .env
 # 2. Edit .env with your values:
 # WALLET_PRIVATE_KEY=0x...    # From MetaMask account details
 # EVM_RPC_URL=https://eth-sepolia...  # From step 3 above
+# ETHERSCAN_API_KEY=...       # For automatic contract verification
 
-# 3. Deploy complete development stack
+# 3. Deploy complete development stack with automatic verification
 make dao-setup
 
 # 4. Copy generated environment variables to cogni-git-admin
@@ -80,8 +81,8 @@ The `make dao-setup` command generates environment variables for cogni-git-admin
 
 ## Contract Details
 
-- **CogniSignal:** `0x8F26cF7b9ca6790385E255E8aB63acc35e7b9FB1` ([Verified on Sepolia](https://sepolia.etherscan.io/address/0x8f26cf7b9ca6790385e255e8ab63acc35e7b9fb1))
-- **DAO:** `0xa38d03Ea38c45C1B6a37472d8Df78a47C1A31EB5`
+- **CogniSignal:** `0x7115D79246D1aE2D4bF5a6D5fA626B426fE8F5cD` ([Verified on Sepolia](https://sepolia.etherscan.io/address/0x7115d79246d1ae2d4bf5a6d5fa626b426fe8f5cd))
+- **DAO:** `0xA382320be88f1c6856d3bcdeBa9Ce5C73A553cB6`
 - **Action:** `PR_APPROVE` - Approve pull requests
 
 ## Documentation

--- a/script/AGENTS.md
+++ b/script/AGENTS.md
@@ -23,8 +23,8 @@ make dao-setup  # Deploys complete stack
 
 **Required Environment:**
 - `WALLET_PRIVATE_KEY` - Funded Sepolia wallet
-- `EVM_RPC_URL` - Sepolia RPC endpoint
-- `ETHERSCAN_API_KEY` - For automatic contract verification
+- `EVM_RPC_URL` - Sepolia RPC endpoint  
+- `ETHERSCAN_API_KEY` - For automatic contract verification ([Get free API key](https://etherscan.io/apidashboard))
 
 **Optional:**
 - `GOV_PROVIDER` - Provider type (default: "aragon")
@@ -45,7 +45,15 @@ cast balance $(cast wallet address --private-key $WALLET_PRIVATE_KEY) --rpc-url 
 
 # Test RPC connectivity  
 cast block latest --rpc-url $EVM_RPC_URL
+
+# Verify Etherscan API key
+curl -s "https://api.etherscan.io/api?module=account&action=balance&address=0x0000000000000000000000000000000000000000&tag=latest&apikey=$ETHERSCAN_API_KEY" | grep -q "OK"
 ```
+
+**Verification Issues:**
+- **Indexing delays**: Wait 30 seconds, retry deployment
+- **Rate limits**: Free tier: 100k requests/day 
+- **Manual fallback**: Use `forge verify-contract` if automatic fails
 
 ## Deploy.s.sol
 

--- a/script/AGENTS.md
+++ b/script/AGENTS.md
@@ -24,6 +24,7 @@ make dao-setup  # Deploys complete stack
 **Required Environment:**
 - `WALLET_PRIVATE_KEY` - Funded Sepolia wallet
 - `EVM_RPC_URL` - Sepolia RPC endpoint
+- `ETHERSCAN_API_KEY` - For automatic contract verification
 
 **Optional:**
 - `GOV_PROVIDER` - Provider type (default: "aragon")
@@ -54,13 +55,9 @@ Deploys CogniSignal with existing DAO.
 make deploy-contract  # Deploy and verify
 ```
 
-**Required:** `DAO_ADDRESS`, `WALLET_PRIVATE_KEY`, `ETHERSCAN_API_KEY`
+**Required:** `DAO_ADDRESS`, `WALLET_PRIVATE_KEY`, `EVM_RPC_URL`, `ETHERSCAN_API_KEY`
 
-**Latest Deployment (Generic Schema):**
-- Sepolia: `0x2762C0875D23784aEF5bABe670f22f98B9248180` (Verified ✅)
-- DAO: `0xd81dAa2433cB8fBf8282B83b52bfb65C6043c62C`
+**Current Deployment (Multi-VCS Schema):**
+- Sepolia: `0x7115D79246D1aE2D4bF5a6D5fA626B426fE8F5cD` (Verified ✅)
+- DAO: `0xA382320be88f1c6856d3bcdeBa9Ce5C73A553cB6`
 - ABI: `signal(string,string,string,string,string,bytes)` + `CogniAction(address,uint256,string,string,string,string,string,bytes,address)` event
-
-**Legacy Deployment (GitHub-only):**
-- Sepolia: `0x8F26cF7b9ca6790385E255E8aB63acc35e7b9FB1` (Verified)
-- DAO: `0xa38d03Ea38c45C1B6a37472d8Df78a47C1A31EB5`


### PR DESCRIPTION

<img width="1024" height="1024" alt="image" src="https://github.com/user-attachments/assets/877b6f42-4abe-4dbd-8068-cb67ac1d7992" />


## Summary
- Add automatic contract verification to deployment targets using `--verify` flag
- Require ETHERSCAN_API_KEY environment variable for both `dao-setup` and `deploy-contract` targets
- Update documentation with latest contract addresses and verification requirements

## Changes
- **Makefile**: Add ETHERSCAN_API_KEY validation and --verify flag to forge scripts
- **Documentation**: Update contract addresses to latest deployment (0x7115D79...)
- **Environment**: Document ETHERSCAN_API_KEY requirement in setup guides

## Test plan
- [x] Verified deployment works with new verification flow
- [x] All 3 contracts successfully verified on Sepolia
- [x] E2E tests pass with updated contract addresses
- [x] Documentation reflects current functionality