### PR TITLE
refactor\!: migrate FaucetMinter from GovernanceERC20 to IERC20/IMint interfaces

### DIFF
--- a/script/AGENTS.md
+++ b/script/AGENTS.md
@@ -97,8 +97,8 @@ forge script GrantMintToFaucet --rpc-url $EVM_RPC_URL --broadcast
 **Output:** Proposal ID for DAO members to vote on
 
 **Permissions Proposed:**
-1. `grantMintRole(faucet)` - Grants faucet minter role on NonTransferableVotes
-2. `CONFIG_PERMISSION_ID` on faucet → DAO (enables amountPerClaim/globalCap updates)  
+1. `token.grantMintRole(faucet)` - Grants faucet minter role on NonTransferableVotes
+2. `CONFIG_PERMISSION_ID` on faucet → DAO (enables globalCap updates)  
 3. `PAUSE_PERMISSION_ID` on faucet → DAO (enables pause/unpause)
 
 **Production Flow:** Use governance UI deeplinks with hardcoded proposal parameters instead of this script.

--- a/script/SetupDevChain.s.sol
+++ b/script/SetupDevChain.s.sol
@@ -2,7 +2,6 @@
 pragma solidity ^0.8.13;
 
 import {Script, console2} from "forge-std/Script.sol";
-import {Deploy} from "./Deploy.s.sol";
 import {CogniSignal} from "../src/CogniSignal.sol";
 import {FaucetMinter} from "../src/FaucetMinter.sol";
 import {IGovProvider} from "./gov_providers/IGovProvider.sol";

--- a/script/gov_providers/Aragon/AGENTS.md
+++ b/script/gov_providers/Aragon/AGENTS.md
@@ -43,14 +43,15 @@ Initial holder receives 1 NonTransferableVotes token.
 
 Uses official Aragon imports plus custom token:
 - `@aragon/osx/framework/dao/DAOFactory.sol`
-- `token-voting-plugin/src/TokenVoting.sol`  
+- `token-voting-plugin/src/TokenVoting.sol`
+- `token-voting-plugin/src/erc20/GovernanceERC20.sol` (for MintSettings structure)
 - `../../../src/NonTransferableVotes.sol`
 
-Deployment via `DAOFactory.createDao()` with empty MintSettings to prevent double-minting.
+Deployment via `DAOFactory.createDao()` with empty `GovernanceERC20.MintSettings` to prevent plugin-side minting.
 
 ## ABI Compatibility
 
-TokenVotingSetup requires 7 parameters (was 3, fixed):
+TokenVotingSetup requires 7 parameters:
 1. VotingSettings  
 2. TokenSettings
 3. MintSettings
@@ -59,7 +60,7 @@ TokenVotingSetup requires 7 parameters (was 3, fixed):
 6. pluginMetadata (bytes)
 7. excludedAccounts (address[])
 
-Fixed 0x20 malformed address decoding by using official imports instead of custom interfaces.
+Official imports provide proper ABI compatibility for address decoding.
 
 
 ## Error Handling

--- a/script/gov_providers/Aragon/AragonOSxProvider.sol
+++ b/script/gov_providers/Aragon/AragonOSxProvider.sol
@@ -3,13 +3,9 @@ pragma solidity ^0.8.13;
 
 // Import real types directly from official plugin sources  
 import {Script, console2} from "forge-std/Script.sol";
-import {Vm} from "forge-std/Vm.sol";
-import {ERC20} from "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 import {Address} from "@openzeppelin/contracts/utils/Address.sol";
 import {IGovProvider} from "../IGovProvider.sol";
 import {DAOFactory} from "@aragon/osx/framework/dao/DAOFactory.sol";
-import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
-import {IPluginSetup} from "@aragon/osx-commons-contracts/src/plugin/setup/IPluginSetup.sol";
 import {PluginSetupRef} from "@aragon/osx/framework/plugin/setup/PluginSetupProcessorHelpers.sol";
 import {PluginRepo} from "@aragon/osx/framework/plugin/repo/PluginRepo.sol";
 import {MajorityVotingBase} from "token-voting-plugin/src/base/MajorityVotingBase.sol";

--- a/src/AGENTS.md
+++ b/src/AGENTS.md
@@ -77,13 +77,13 @@ Token faucet enabling one-time governance token claims with DAO-controlled confi
 
 ### Core Functions
 ```solidity
-function claim() external nonReentrant;              // Mint tokens to msg.sender
+function claim() external nonReentrant;              // Mint 1e18 tokens to msg.sender
 function pause(bool _paused) external auth(PAUSE_PERMISSION);  // DAO pause control
-function setAmountPerClaim(uint256) external auth(CONFIG_PERMISSION);
-function setGlobalCap(uint256) external auth(CONFIG_PERMISSION);
+function setGlobalCap(uint256) external auth(CONFIG_PERMISSION); // Update total cap
 ```
 
 ### Token Integration
-- Calls `token.mint(msg.sender, amountPerClaim)` on claim
-- Requires minter role on NonTransferableVotes token
-- DAO grants minter role via: `token.grantMintRole(faucetAddress)`
+- Uses `IERC20` interface for token reads and `IMint` interface for minting
+- Fixed amount: mints exactly 1e18 tokens per claim (matches token constraint)
+- Requires minter role: faucet must be granted `minters[faucet] = true`
+- DAO grants via proposal: `token.grantMintRole(faucetAddress)`

--- a/src/FaucetMinter.sol
+++ b/src/FaucetMinter.sol
@@ -84,7 +84,7 @@ contract FaucetMinter is ReentrancyGuard, DaoAuthorizable {
     
     /**
      * @notice Claim tokens (one time per address)
-     * @dev Requires MINT_PERMISSION_ID to be granted to this contract by the DAO
+     * @dev Requires faucet to be a minter on the token (DAO grants via proposal)
      */
     function claim() external nonReentrant {
         if (paused) revert FaucetPaused();

--- a/src/FaucetMinter.sol
+++ b/src/FaucetMinter.sol
@@ -4,7 +4,11 @@ pragma solidity ^0.8.13;
 import {ReentrancyGuard} from "@openzeppelin/contracts/security/ReentrancyGuard.sol";
 import {DaoAuthorizable} from "@aragon/osx-commons-contracts/src/permission/auth/DaoAuthorizable.sol";
 import {IDAO} from "@aragon/osx-commons-contracts/src/dao/IDAO.sol";
-import {GovernanceERC20} from "token-voting-plugin/src/erc20/GovernanceERC20.sol";
+import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IMint { 
+    function mint(address to, uint256 amount) external; 
+}
 
 /**
  * @title FaucetMinter
@@ -12,14 +16,17 @@ import {GovernanceERC20} from "token-voting-plugin/src/erc20/GovernanceERC20.sol
  * @notice Mints governance tokens to users who haven't claimed before
  */
 contract FaucetMinter is ReentrancyGuard, DaoAuthorizable {
-    /// @notice The governance token to mint
-    GovernanceERC20 public immutable token;
+    /// @notice The governance token (for reads)
+    IERC20 public immutable token;
+    /// @notice The token minter interface
+    IMint private immutable minter;
     
     /// @notice Permission ID constants
     bytes32 public constant PAUSE_PERMISSION_ID = keccak256("PAUSE_PERMISSION");
     bytes32 public constant CONFIG_PERMISSION_ID = keccak256("CONFIG_PERMISSION");
     
-    /// @notice Amount of tokens to mint per claim
+    /// @notice Amount of tokens to mint per claim (fixed at 1e18)
+    uint256 public constant ONE = 1e18;
     uint256 public amountPerClaim;
     
     /// @notice Maximum total tokens that can ever be minted by this faucet
@@ -65,10 +72,11 @@ contract FaucetMinter is ReentrancyGuard, DaoAuthorizable {
         uint256 _amountPerClaim,
         uint256 _globalCap
     ) DaoAuthorizable(IDAO(_dao)) {
-        if (_amountPerClaim == 0) revert ZeroAmount();
+        if (_amountPerClaim != ONE) revert ZeroAmount();
         if (_globalCap < _amountPerClaim) revert InvalidCap(_globalCap);
         
-        token = GovernanceERC20(_token);
+        token = IERC20(_token);
+        minter = IMint(_token);
         amountPerClaim = _amountPerClaim;
         globalCap = _globalCap;
         paused = false;
@@ -88,7 +96,7 @@ contract FaucetMinter is ReentrancyGuard, DaoAuthorizable {
         claimed[msg.sender] = true;
         totalMinted += amountPerClaim;
         
-        token.mint(msg.sender, amountPerClaim);
+        minter.mint(msg.sender, ONE); // token enforces 1e18 anyway
         
         emit Claimed(msg.sender, amountPerClaim);
     }
@@ -103,19 +111,7 @@ contract FaucetMinter is ReentrancyGuard, DaoAuthorizable {
         emit PauseToggled(_paused);
     }
     
-    /**
-     * @notice Update the amount minted per claim
-     * @param _newAmount New amount to mint per claim
-     * @dev Only callable by the DAO
-     */
-    function setAmountPerClaim(uint256 _newAmount) external auth(CONFIG_PERMISSION_ID) {
-        if (_newAmount == 0) revert ZeroAmount();
-        
-        uint256 oldAmount = amountPerClaim;
-        amountPerClaim = _newAmount;
-        
-        emit AmountPerClaimUpdated(oldAmount, _newAmount);
-    }
+    // removed: amountPerClaim is fixed at 1e18 to align with token invariant
     
     /**
      * @notice Update the global cap
@@ -146,13 +142,5 @@ contract FaucetMinter is ReentrancyGuard, DaoAuthorizable {
      */
     function remainingTokens() external view returns (uint256) {
         return globalCap - totalMinted;
-    }
-    
-    /**
-     * @notice Get the MINT_PERMISSION_ID from the token contract
-     * @return The mint permission ID required for this faucet to work
-     */
-    function getMintPermissionId() external view returns (bytes32) {
-        return token.MINT_PERMISSION_ID();
     }
 }

--- a/src/NonTransferableVotes.sol
+++ b/src/NonTransferableVotes.sol
@@ -11,9 +11,8 @@ contract NonTransferableVotes is ERC20, ERC20Votes, Ownable {
 
     constructor(string memory n, string memory s)
         ERC20(n, s)
-        ERC20Permit(n)   // v4 needs name here
-        Ownable()        // v4: owner = msg.sender
-    {}
+        ERC20Permit(n)   // v4: name here
+    {} 
 
     // block nonzero→nonzero transfers; allow mint (from=0) and burn (to=0)
     function _beforeTokenTransfer(address from, address to, uint256 amount)

--- a/test/unit/AGENTS.md
+++ b/test/unit/AGENTS.md
@@ -116,7 +116,7 @@ function test_RevertWhen_InvalidInput() public {
 
 **Access Control Tests:**
 - DAO can pause/unpause faucet
-- DAO can update configuration (amount per claim, global cap)
+- DAO can update global cap configuration
 - Non-DAO addresses cannot access restricted functions
 
 **Reentrancy Protection:**
@@ -129,5 +129,5 @@ function test_RevertWhen_InvalidInput() public {
 - Permission ID constants match expected values
 
 ### Mock Contracts
-- `MockDAO`: Simulates Aragon DAO permission system
-- `MockToken`: Simulates GovernanceERC20 with mint functionality and permissions
+- `MockDAO`: Simulates Aragon DAO permission system for faucet authorization
+- `MockToken`: Simulates NonTransferableVotes with `grantMintRole()` and fixed 1e18 minting


### PR DESCRIPTION
<img width="1536" height="1024" alt="image" src="https://github.com/user-attachments/assets/87df33cc-0800-4b44-a167-b553fef49f1d" />

## Summary

Migrates FaucetMinter from Aragon GovernanceERC20 dependency to clean IERC20/IMint interfaces that work with NonTransferableVotes token.

This maximizes future compatibility with other DAO interfaces, not hard-bound to Aragon. 

## Changes

- **Interface Migration**: Replace `GovernanceERC20` with `IERC20` + minimal `IMint` interface
- **Fixed Amount**: Amount per claim hardcoded to 1e18 (matches NonTransferableVotes constraint)  
- **Permission System**: Change from Aragon `MINT_PERMISSION` to direct minter role calls
- **Script Updates**: GrantMintToFaucet now uses `token.grantMintRole(faucet)` instead of DAO permissions
- **Test Updates**: MockToken updated to enforce NonTransferableVotes behavior (1e18 fixed, one-per-address)
- **Import Cleanup**: Remove unused dependencies across multiple files

## Breaking Changes

These are breaking changes.... except the functionality was introduced 1 PR ago. So not a problem at all.

- ❌ Removed `setAmountPerClaim()` function (amount now fixed at 1e18)
- ❌ Removed `getMintPermissionId()` function (no longer using Aragon permission system)
- ⚠️ Changed token interface expectations from `GovernanceERC20` to `IERC20`/`IMint`

## Test Plan

- [x] All unit tests pass with updated MockToken
- [x] Forge build succeeds 
- [x] Manual deployment and faucet workflow tested successfully